### PR TITLE
Dynamically Define Auth Module

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ openvpn_as_password: $6$j8B0A1aiU$53BF5A6qO74IDJWTDqgaafnBar1c.LOKK7sdBxwXJY/K/I
 openvpn_as_admin_ui_https_ip_address: "{{ ansible_default_ipv4.interface }}"
 openvpn_as_admin_ui_https_port: 943
 
+openvpn_as_auth_module_type: pam
 openvpn_as_connect: true
 
 openvpn_as_cs_admin_only: false

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -6,7 +6,7 @@
     "auth.ldap.0.ssl_verify": "never",
     "auth.ldap.0.timeout": "4",
     "auth.ldap.0.use_ssl": "never",
-    "auth.module.type": "pam",
+    "auth.module.type": "{{ openvpn_as_auth_module_type }}",
     "auth.pam.0.service": "openvpnas",
     "auth.radius.0.acct_enable": "false",
     "auth.radius.0.name": "My Radius servers",

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,4 +1,4 @@
 ---
 # vars file for openvpn_as (Ubuntu specific)
 
-openvpn_as_url: http://swupdate.openvpn.org/as/openvpn-as-{{ openvpn_as_version }}-Ubuntu{{ ansible_distribution_version | truncate(2, True, '') }}.amd_64.deb
+openvpn_as_url: https://swupdate.openvpn.org/as/openvpn-as-{{ openvpn_as_version }}-Ubuntu{{ ansible_distribution_version | truncate(2, True, '') }}.amd_64.deb

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,4 +1,4 @@
 ---
 # vars file for openvpn_as (Ubuntu specific)
 
-openvpn_as_url: https://swupdate.openvpn.org/as/openvpn-as-{{ openvpn_as_version }}-Ubuntu{{ ansible_distribution_version | truncate(2, True, '') }}.amd_64.deb
+openvpn_as_url: https://swupdate.openvpn.org/as/openvpn-as-{{ openvpn_as_version }}-Ubuntu{{ ansible_distribution_version | truncate(2, True, '', 0) }}.amd_64.deb


### PR DESCRIPTION
Continues to default to `pam`, but allows for other auth methods OpenVPN supports to be specified.