### PR TITLE
Enable vpn.server.tls_auth by default for newer versions

### DIFF
--- a/templates/as.conf.j2
+++ b/templates/as.conf.j2
@@ -56,3 +56,4 @@ iptables.web=false
 {% endif %}
 vpn.server.user=openvpn_as
 vpn.server.group=openvpn_as
+vpn.server.tls_auth=true


### PR DESCRIPTION
If you use 2.1.12 (the newest version), this config missing may result in Access Server persisting the wrong default to the backend.

2.1.12 also appears to be working well for us, would you like me to bump the version in this PR as well @kbrebanov?