### PR TITLE
custom SSL cert

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for openvpn_as
 
 openvpn_as_version: 2.1.2
-
+openvpn_as_custom_cert: false
 openvpn_as_ubuntu_trusty_sha256sum: d9d539e7a497ed36a15100a8f24e4fcb42b98581bfc5d79e0bb07b7e4c4a608b
 openvpn_as_ubuntu_xenial_sha256sum: f00cf38d9fb51beb66ddb9d67b508952d9170b6d94e821465a09d58fb14ce475
 

--- a/templates/as.conf.j2
+++ b/templates/as.conf.j2
@@ -42,9 +42,15 @@ cs.auto_generate=true
 {% else %}
 cs.auto_generate=false
 {% endif %}
+{% if openvpn_as_custom_cert %}
+cs.ca_bundle={{ openvpn_as_ca_bundle }}
+cs.priv_key={{ openvpn_as_ca_priv_key }}
+cs.cert={{ openvpn_as_ca_cert }}
+{% else %}
 cs.ca_bundle=~/web-ssl/ca.crt
 cs.priv_key=~/web-ssl/server.key
 cs.cert=~/web-ssl/server.crt
+{% endif %}
 cs.dynamic_port_base=870
 sa.initial_run_groups.0=web_group
 sa.reactor=epoll


### PR DESCRIPTION
This allows for a customer SSL cert to be used on the web interface.  

openvpn_as_custom_cert: true

This then requires you to be sure your files are in place, and that you define the following variables.

openvpn_as_ca_bundle
openvpn_as_ca_priv_key
openvpn_as_ca_cert